### PR TITLE
Add task-based parallelization strategy using the Tokio runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "crossbeam",
+ "futures",
  "glob",
  "godunov-core",
  "hdf5",
@@ -47,6 +48,7 @@ dependencies = [
  "ndarray",
  "ndarray-ops",
  "num",
+ "tokio",
 ]
 
 [[package]]
@@ -178,6 +180,101 @@ dependencies = [
  "autocfg",
  "cfg-if 0.1.10",
  "lazy_static",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "futures-util"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
@@ -470,6 +567,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
 name = "os_str_bytes"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +613,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +673,18 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
@@ -601,10 +758,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.4.2"
+name = "slab"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "smallvec"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 
 [[package]]
 name = "strsim"
@@ -648,6 +811,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tokio"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ca08accbcb46f11fd8d2d1c6158c348b7888009a1f39260bcad66f6a454250"
+dependencies = [
+ "autocfg",
+ "num_cpus",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "ndarray",
  "ndarray-ops",
  "num",
+ "num_cpus",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 [[package]]
 name = "godunov-core"
 version = "0.1.0"
-source = "git+https://github.com/clemson-cal/godunov-core#e3ddfe506444a99b4541f4351fe52d13c6000541"
+source = "git+https://github.com/clemson-cal/godunov-core#03c50839f814aa449febbd955403849196bc2aa3"
 dependencies = [
  "ndarray",
  "num",
@@ -615,18 +615,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
+checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
 
 [[package]]
 name = "pin-utils"
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
@@ -816,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ca08accbcb46f11fd8d2d1c6158c348b7888009a1f39260bcad66f6a454250"
+checksum = "9dfe2523e6fa84ddf5e688151d4e5fddc51678de9752c6512a24714c23818d61"
 dependencies = [
  "autocfg",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ ndarray         = "0.13"
 hdf5            = "0.7"
 clap            = "3.0.0-beta"
 glob            = "0.3"
+futures         = "0.3"
+tokio           = { version = "0.3", features = ["rt-multi-thread"] }
 
 kind-config     = { git = "https://github.com/clemson-cal/kind-config", features = ["hdf5"] }
 kepler-two-body = { git = "https://github.com/clemson-cal/kepler-two-body" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ ndarray         = "0.13"
 hdf5            = "0.7"
 clap            = "3.0.0-beta"
 glob            = "0.3"
+num_cpus        = "1.0"
 futures         = "0.3"
 tokio           = { version = "0.3", features = ["rt-multi-thread"] }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -33,7 +33,8 @@ pub fn read_state(filename: &str) -> Result<crate::State, hdf5::Error>
         let u = cons.dataset(&key)?
             .read_dyn::<[f64; 3]>()?
             .into_dimensionality::<ndarray::Ix2>()?
-            .mapv(Into::<hydro_iso2d::Conserved>::into);
+            .mapv(Into::<hydro_iso2d::Conserved>::into)
+            .to_shared();
         conserved.push(u);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,8 +304,7 @@ fn run(app: App) -> Result<(), Box<dyn std::error::Error>>
         if app.tokio {
             state = scheme::advance_tokio(state, &block_data, &mesh, &solver, dt, app.fold, &runtime);
         } else {
-            panic!();
-            // scheme::advance_channels(&mut state, &block_data, &mesh, &solver, dt, app.fold);
+            scheme::advance_channels(&mut state, &block_data, &mesh, &solver, dt, app.fold);
         }
         tasks.perform(&state, &block_data, &mesh, &model, &app);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,7 +302,7 @@ fn run(app: App) -> Result<(), Box<dyn std::error::Error>>
     while state.time < tfinal * ORBITAL_PERIOD
     {
         if app.tokio {
-            state = scheme::advance_tokio(state, &block_data, &mesh, &solver, dt, &runtime);
+            state = scheme::advance_tokio(state, &block_data, &mesh, &solver, dt, app.fold, &runtime);
         } else {
             scheme::advance_channels(&mut state, &block_data, &mesh, &solver, dt, app.fold);
         }


### PR DESCRIPTION
This version adds a `--tokio` runtime option. It uses a different parallelization strategy, based on futures and a multithreaded, work-stealing executor from the Tokio crate. There is also a new option `--threads` to specify the number of worker threads in the Tokio runtime. This is 1 by default, but setting it to the number of physical cores on your machine should be optimal. `--threads` is ignored in message-passing mode, because message passing only works with one thread / block.

The performance characteristics with `--tokio` are different from the message-passing parallelization strategy (based on channels from the Crossbeam crate) in a few ways:

- Single-block / single-threaded execution is about 10% slower with `--tokio`
- Parallel execution with blocks ~ threads is as bad as 50% slower
- Parallel execution with blocks >> threads is as much as 2x faster

The last configuration with `--tokio` approaches ~70% scaling up to 28 cores on my workstation, topping 90 Mzps per RK step, with block size 64. Message passing with blocks ~ physical cores tops out at ~100 Mzps with message passing.

Since the optimal mode depends on the mesh configuration, it may be preferable to maintain both parallelization strategies. That should not mean we need to support all runtime configurations in both parallelization modes; it should be ok for e.g. tracer particles to work only with the `--tokio` option.